### PR TITLE
#4 Compatibility with Confluence 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>shibauth</groupId>
     <artifactId>remoteUserAuth</artifactId>
-    <version>2.1.17-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <properties>
-        <confluence.version>4.3.2</confluence.version>
+        <confluence.version>5.0</confluence.version>
         <!-- Look at pom.xml in confluence version in https://maven.atlassian.com/content/repositories/atlassian-public/com/atlassian/confluence/confluence-project/ -->
         <crowd.version>2.5.1</crowd.version>
         <crowd.embedded.version>1.5.3</crowd.embedded.version>

--- a/src/main/java/shibauth/confluence/authentication/shibboleth/RemoteUserAuthenticator.java
+++ b/src/main/java/shibauth/confluence/authentication/shibboleth/RemoteUserAuthenticator.java
@@ -842,7 +842,7 @@ public class RemoteUserAuthenticator extends ConfluenceAuthenticator {
 		getLoginManager().onSuccessfulLoginAttempt(username, request);
 		getEventPublisher().publish(
 		new LoginEvent(this, username, request.getSession().getId(),
-						remoteHost, remoteIP));
+						remoteHost, remoteIP, LoginEvent.UNKNOWN));
 		LoginReason.OK.stampRequestResponse(request, response);
 	}
     


### PR DESCRIPTION
Since it breaks back compat with Confluence 4.x and earlier, might be best as it's own branch/tag or something, but your call.
