### PR TITLE
Local login property is incorrectly loaded in configuration.

### DIFF
--- a/src/main/java/shibauth/confluence/authentication/shibboleth/ShibAuthConfigLoader.java
+++ b/src/main/java/shibauth/confluence/authentication/shibboleth/ShibAuthConfigLoader.java
@@ -75,7 +75,7 @@ public class ShibAuthConfigLoader {
                     Boolean.valueOf(configProps.getProperty(ShibAuthConstants.LOCAL_LOGIN_SUPPORTED, "true")).booleanValue());
 
             if (log.isDebugEnabled()) {
-                log.debug("Setting create new users to " + config.isCreateUsers());
+                log.debug("Setting local login supported to " + config.isLocalLoginSupported());
             }
 
             // Load create.users property.

--- a/src/main/java/shibauth/confluence/authentication/shibboleth/ShibAuthConfigLoader.java
+++ b/src/main/java/shibauth/confluence/authentication/shibboleth/ShibAuthConfigLoader.java
@@ -71,7 +71,7 @@ public class ShibAuthConfigLoader {
             configProps.load(propsIn);
 
             // Load local.login.supported property.
-            config.setCreateUsers(
+            config.setLocalLoginSupported(
                     Boolean.valueOf(configProps.getProperty(ShibAuthConstants.LOCAL_LOGIN_SUPPORTED, "true")).booleanValue());
 
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
Property was stored in CreateUsers instead. This fix sets the value at the correct location