### PR TITLE
Updated method getCNMatches() to verify Matcher group before assignement. Added config fix 'username.filter=CN=([A-Za-z0-9]*)' to fix CN=C*.

### DIFF
--- a/conf/remoteUserAuthenticator.properties
+++ b/conf/remoteUserAuthenticator.properties
@@ -72,7 +72,7 @@ username.convertcase=true
 # This filter supports a strategy to get user id attribute value by default as first attribute or use custom one. Strategy codes mean the following:
 # 0 - Get user id attribute value as first attribute from the header
 # 1 - Use username.filter to get custom attribute
-username.filter=^CN=(.*)
+username.filter=CN=([A-Za-z0-9]*)
 #username.filter.strategy=0
 
 # Indication whether the group memberships of the user should be updated after creation. Acceptable values: true/false.

--- a/src/main/java/shibauth/confluence/authentication/shibboleth/StringUtil.java
+++ b/src/main/java/shibauth/confluence/authentication/shibboleth/StringUtil.java
@@ -101,7 +101,7 @@ public class StringUtil {
             Matcher m = p.matcher(list.get(i));
 
             if (m.matches()) {
-                String tmpResult = m.group(0);
+                String tmpResult = m.group(1);
 
                 if (tmpResult != null && !tmpResult.equals("") ) {
                     matches.add(tmpResult);

--- a/src/main/java/shibauth/confluence/authentication/shibboleth/StringUtil.java
+++ b/src/main/java/shibauth/confluence/authentication/shibboleth/StringUtil.java
@@ -100,10 +100,12 @@ public class StringUtil {
         for (int i = 0; i < list.size(); i++) {
             Matcher m = p.matcher(list.get(i));
 
-            String tmpResult = m.group(0);
+            if (m.matches()) {
+                String tmpResult = m.group(0);
 
-            if (m.matches() && tmpResult != null && !tmpResult.equals("") ) {
-                matches.add(tmpResult);
+                if (tmpResult != null && !tmpResult.equals("") ) {
+                    matches.add(tmpResult);
+                }
             }
         }
 


### PR DESCRIPTION
Hi, folks, bugfix for PR https://github.com/chauth/confluence_http_authenticator/pull/53.